### PR TITLE
Fix work report rate

### DIFF
--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -171,7 +171,7 @@ export const historyPubKeyReports = async (currentReportSlot: number) => {
   const results = await Events.aggregate([
     {
       $match: {
-        reportSlot: {$lt: currentReportSlot + 1, $gte: startSlot},
+        reportSlot: {$lte: currentReportSlot, $gte: startSlot},
         section: 'swork',
         method: 'WorksReportSuccess',
       },

--- a/src/services/nodeStatusService.ts
+++ b/src/services/nodeStatusService.ts
@@ -90,7 +90,8 @@ export default class NodeStatusService {
   }
 
   public reportStatusUpdateMany = async (currentSlot: number) => {
-    const pubKeyReports = await db.historyPubKeyReports(currentSlot);
+    const ps = preSlot(currentSlot);
+    const pubKeyReports = await db.historyPubKeyReports(ps);
     const reportedPubKeys = pubKeyReports.map((pk: {_id: any}) => pk._id);
     await db.updateUnReportedPubKey(reportedPubKeys);
     for (const pubKeyReport of pubKeyReports) {
@@ -103,14 +104,14 @@ export default class NodeStatusService {
           await db.updateStatusAndEffectiveSlot(
             dbReportStatus._id,
             pubKeyReport.reportCount,
-            preSlot(currentSlot),
-            preSlot(currentSlot)
+            ps,
+            ps
           );
         } else {
           await db.reportedStatusUpdate(
             dbReportStatus._id,
             pubKeyReport.reportCount,
-            preSlot(currentSlot)
+            ps
           );
         }
       } else {
@@ -154,10 +155,10 @@ export default class NodeStatusService {
                 0
               );
           const totalReportCount = totalReportedSlotsBN / 300 + 1;
-          totalReportRate += this.getPercent(
-            pubKeyWorkReport.reportedCount,
-            totalReportCount
-          );
+          totalReportRate += Math.min(this.getPercent(
+              pubKeyWorkReport.reportedCount,
+              totalReportCount
+          ), 1) ;
         }
       }
       const reportRate = Math.min(


### PR DESCRIPTION
### Work report rate description
Work report rate calculation based on `WorkReportSuccess` event, which we re-calculation every report slot change. The algorithm should be calculate with **[ark_started_slot, current_report_slot - 300]** and **report_rate = avg(total_report_rate)**

### This pr fix
1. Using `current_report_slot - 300`(previous report slot);
2. `total_report_rate` should not add with `> 100%` value;